### PR TITLE
refactor: rewrite deep clone of Drug array to make it more understandable

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -12,8 +12,9 @@ const trial = new Pharmacy(drugs);
 const log = [];
 
 for (let elapsedDays = 0; elapsedDays < 30; elapsedDays++) {
-  const updated = trial.updateBenefitValue()
-  log.push(JSON.parse(JSON.stringify(updated)))
+  const updatedDrugs = trial.updateBenefitValue();
+  const updatedDrugsDeepClone = updatedDrugs.map((drug) => ({ ...drug }));
+  log.push(updatedDrugsDeepClone);
 }
 
 /* eslint-disable no-console */


### PR DESCRIPTION
### Description
- we previously added a `JSON.parse(JSON.stringify())` to fix a reference vs clone issue in the Drugs array.
- although it's (arguably?) an accepted answer for Deep cloning JS classes (https://stackoverflow.com/a/59500148/5186918), it doesn't really convey intent
- it's probably more explicit to really clone the content of the array
- note that trying to clone the the array ([...updatedDrugs]), doesn't work, since it actually clones the reference to the array, but the new array still contains the *references* to the same Drug instances. It's essentially the difference between "deep clone" and "shallow clone"